### PR TITLE
add:model lgtmを作成

### DIFF
--- a/app/models/lgtm.rb
+++ b/app/models/lgtm.rb
@@ -1,0 +1,2 @@
+class Lgtm < ApplicationRecord
+end

--- a/db/migrate/20250330105155_create_lgtms.rb
+++ b/db/migrate/20250330105155_create_lgtms.rb
@@ -1,0 +1,9 @@
+class CreateLgtms < ActiveRecord::Migration[7.2]
+  def change
+    create_table :lgtms do |t|
+      t.string :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,22 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2025_03_30_105155) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "lgtms", force: :cascade do |t|
+    t.string "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/test/fixtures/lgtms.yml
+++ b/test/fixtures/lgtms.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/lgtm_test.rb
+++ b/test/models/lgtm_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LgtmTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This pull request introduces a new model `Lgtm` to the application, including necessary database migrations, schema updates, and test fixtures. The primary changes involve creating the model, setting up the database table, and adding basic test infrastructure.

Model and Database Setup:

* [`app/models/lgtm.rb`](diffhunk://#diff-19b76276b7328729346dd0133d62c2b71c9691eb561b46dcc692b3e99a23ca6eR1-R2): Created a new model class `Lgtm`.
* [`db/migrate/20250330105155_create_lgtms.rb`](diffhunk://#diff-6ba82306b9200efed63bdcbdba0db043b321edeeaedb76456265a43b726fd89aR1-R9): Added a migration to create the `lgtms` table with a `content` column and timestamps.
* [`db/schema.rb`](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R1-R22): Updated the schema to include the new `lgtms` table definition.

Testing Infrastructure:

* [`test/fixtures/lgtms.yml`](diffhunk://#diff-214eb3f5fd80feae12167b42b27e55477fb81674ddea54d384deb99ab1841d83R1-R11): Added fixture file for `Lgtm` model with placeholder entries.
* [`test/models/lgtm_test.rb`](diffhunk://#diff-d1832833a3e16dedf5438edd935a338a407ddec11573acf083a374713051d207R1-R7): Created a basic test file for the `Lgtm` model.